### PR TITLE
Add font and emoji font settings

### DIFF
--- a/bridges.go
+++ b/bridges.go
@@ -85,6 +85,8 @@ type ConfigBridge struct {
 	_ int    `property:"positionY"`
 	_ int    `property:"width"`
 	_ int    `property:"height"`
+	_ string `property:"fontfamily"`
+	_ string `property:"emojifont"`
 }
 
 var (

--- a/config.go
+++ b/config.go
@@ -17,14 +17,16 @@ type Account struct {
 
 // Config holds telephant's config settings
 type Config struct {
-	Account   []Account
-	Theme     string
-	Style     string
-	PositionX int
-	PositionY int
-	Width     int
-	Height    int
-	FirstRun  bool
+	Account    []Account
+	Theme      string
+	Style      string
+	PositionX  int
+	PositionY  int
+	Width      int
+	Height     int
+	FirstRun   bool
+	FontFamily string
+	EmojiFont  string
 }
 
 // LoadConfig returns the current config as a Config struct

--- a/events.go
+++ b/events.go
@@ -3,9 +3,26 @@ package main
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/muesli/telephant/accounts"
+	"github.com/tachiniererin/bananasplit"
 )
+
+func addEmojiFont(body string) string {
+	runeRange := map[string][]bananasplit.RuneRange{"emoji": bananasplit.EmojiRange}
+	bodyParts := bananasplit.SplitByRanges(body, runeRange)
+	var mon strings.Builder
+	for _, part := range bodyParts {
+		if part.Type == "emoji" {
+			mon.WriteString(fmt.Sprintf(`<font face="%s">%s</font>`, config.EmojiFont, part.Text))
+		} else {
+			mon.WriteString(part.Text)
+		}
+	}
+
+	return mon.String()
+}
 
 // handleEvents handles incoming events and puts them into the right models
 func handleEvents(eventsIn chan interface{}, messages *MessageModel) {
@@ -22,7 +39,7 @@ func handleEvents(eventsIn chan interface{}, messages *MessageModel) {
 			{
 				log.Println("Account login succeeded:", event.Username, event.Name, event.Avatar)
 				accountBridge.SetUsername(event.Username)
-				accountBridge.SetName(event.Name)
+				accountBridge.SetName(addEmojiFont(event.Name))
 				accountBridge.SetAvatar(event.Avatar)
 				accountBridge.SetProfileURL(event.ProfileURL)
 				accountBridge.SetProfileID(event.ProfileID)
@@ -54,6 +71,9 @@ func handleEvents(eventsIn chan interface{}, messages *MessageModel) {
 				// log.Println("Message received:", spw.Sdump(event))
 
 				p := messageFromEvent(event)
+				p.Name = addEmojiFont(p.Name)
+				p.ActorName = addEmojiFont(p.ActorName)
+				p.Body = addEmojiFont(p.Body)
 
 				// markup links
 				/*

--- a/qml/AboutDialog.qml
+++ b/qml/AboutDialog.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
     Popup {

--- a/qml/AboutDialog.qml
+++ b/qml/AboutDialog.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
     Popup {
         modal: true

--- a/qml/AccountPopup.qml
+++ b/qml/AccountPopup.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 Popup {
     id: accountPopup

--- a/qml/AccountPopup.qml
+++ b/qml/AccountPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 Popup {

--- a/qml/AccountSummary.qml
+++ b/qml/AccountSummary.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 import "componentCreator.js" as ComponentCreator

--- a/qml/AccountSummary.qml
+++ b/qml/AccountSummary.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 import "componentCreator.js" as ComponentCreator
 

--- a/qml/ConnectDialog.qml
+++ b/qml/ConnectDialog.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 Popup {
     id: connectDialog

--- a/qml/ConnectDialog.qml
+++ b/qml/ConnectDialog.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 Popup {

--- a/qml/ConversationPopup.qml
+++ b/qml/ConversationPopup.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 Popup {
     id: conversationPopup

--- a/qml/ConversationPopup.qml
+++ b/qml/ConversationPopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 Popup {

--- a/qml/DeletePopup.qml
+++ b/qml/DeletePopup.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 Popup {
     property var message

--- a/qml/DeletePopup.qml
+++ b/qml/DeletePopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 Popup {

--- a/qml/ImageButton.qml
+++ b/qml/ImageButton.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.5
-import QtQuick.Controls 2.1
-import QtGraphicalEffects 1.0
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtGraphicalEffects 1.12
 
 Image {
     id: img

--- a/qml/ImageButton.qml
+++ b/qml/ImageButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 import QtGraphicalEffects 1.12
 
 Image {

--- a/qml/MediaPopup.qml
+++ b/qml/MediaPopup.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
-import QtMultimedia 5.13
+import QtMultimedia 5.12
 
 Popup {
     property var url

--- a/qml/MediaPopup.qml
+++ b/qml/MediaPopup.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
-import QtMultimedia 5.9
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
+import QtMultimedia 5.13
 
 Popup {
     property var url

--- a/qml/MessageDelegate.qml
+++ b/qml/MessageDelegate.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
+import QtGraphicalEffects 1.12
 
 ColumnLayout {
     property bool fadeMedia

--- a/qml/MessageDelegate.qml
+++ b/qml/MessageDelegate.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 import QtGraphicalEffects 1.12
 

--- a/qml/MessageList.qml
+++ b/qml/MessageList.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 ListView {
     property bool fadeMedia: true

--- a/qml/MessageList.qml
+++ b/qml/MessageList.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 ListView {
     property bool fadeMedia: true

--- a/qml/MessagePane.qml
+++ b/qml/MessagePane.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 ColumnLayout {

--- a/qml/MessagePane.qml
+++ b/qml/MessagePane.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 ColumnLayout {
     property int idx

--- a/qml/MessagePopup.qml
+++ b/qml/MessagePopup.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
-import QtQuick.Dialogs 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
+import QtQuick.Dialogs 1.11
 
 Popup {
     id: popup

--- a/qml/MessagePopup.qml
+++ b/qml/MessagePopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 import QtQuick.Dialogs 1.11
 

--- a/qml/MessagePopup.qml
+++ b/qml/MessagePopup.qml
@@ -2,7 +2,7 @@ import QtQuick 2.12
 import QtQuick.Controls 2.12
 import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
-import QtQuick.Dialogs 1.11
+import QtQuick.Dialogs 1.3
 
 Popup {
     id: popup

--- a/qml/MessageText.qml
+++ b/qml/MessageText.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 
 import "componentCreator.js" as ComponentCreator
 

--- a/qml/MessageText.qml
+++ b/qml/MessageText.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.5
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.1
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
 
 import "componentCreator.js" as ComponentCreator
 

--- a/qml/MessageView.qml
+++ b/qml/MessageView.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 import QtGraphicalEffects 1.12
 

--- a/qml/MessageView.qml
+++ b/qml/MessageView.qml
@@ -1,8 +1,8 @@
-import QtQuick 2.5
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
-import QtGraphicalEffects 1.0
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
+import QtGraphicalEffects 1.12
 
 import "componentCreator.js" as ComponentCreator
 
@@ -33,6 +33,7 @@ ColumnLayout {
             font.pointSize: 10
             text: qsTr("%1 shared").arg(message.actorname)
             opacity: (accountBridge.username == message.author && (message.like || message.forward)) ? 0.8 : 0.3
+            textFormat: Text.RichText
 
             MouseArea {
                 anchors.fill: parent
@@ -59,6 +60,7 @@ ColumnLayout {
             font.pointSize: 10
             text: qsTr("%1 liked").arg(message.actorname)
             opacity: (accountBridge.username == message.author && (message.like || message.forward)) ? 0.8 : 0.3
+            textFormat: Text.RichText
 
             MouseArea {
                 anchors.fill: parent
@@ -101,7 +103,7 @@ ColumnLayout {
                     font.pointSize: 11
                     font.bold: true
                     text: qsTr("%1 followed you").arg(message.actorname)
-                    textFormat: Text.PlainText
+                    textFormat: Text.RichText
                     Layout.fillWidth: true
                     elide: Text.ElideRight
 
@@ -117,7 +119,7 @@ ColumnLayout {
                 Label {
                     font.pointSize: 11
                     text: message.actor
-                    textFormat: Text.PlainText
+                    textFormat: Text.RichText
                     Layout.fillWidth: true
                     elide: Text.ElideRight
 
@@ -154,7 +156,7 @@ ColumnLayout {
                     font.pointSize: 11
                     font.bold: true
                     text: message.name
-                    textFormat: Text.PlainText
+                    textFormat: Text.RichText
                     elide: Text.ElideRight
                     opacity: (accountBridge.username == message.author && (message.like || message.forward)) ? 0.4 : 1.0
                     Layout.fillWidth: true
@@ -174,7 +176,7 @@ ColumnLayout {
                     font.pointSize: 9
                     opacity: 0.4
                     text: "@" + message.author
-                    textFormat: Text.PlainText
+                    textFormat: Text.RichText
                     elide: Text.ElideRight
                     Layout.fillWidth: true
                     Layout.maximumWidth: implicitWidth + 1

--- a/qml/ScrollHelper.qml
+++ b/qml/ScrollHelper.qml
@@ -17,8 +17,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 /*
 * The MouseArea + interactive: false + maximumFlickVelocity are required

--- a/qml/ScrollHelper.qml
+++ b/qml/ScrollHelper.qml
@@ -17,8 +17,8 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-import QtQuick 2.7
-import QtQuick.Controls 2
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 /*
 * The MouseArea + interactive: false + maximumFlickVelocity are required

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 Popup {
     modal: true

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 Popup {

--- a/qml/SharePopup.qml
+++ b/qml/SharePopup.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.1
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 Popup {
     property var message

--- a/qml/SharePopup.qml
+++ b/qml/SharePopup.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 Popup {

--- a/qml/TextButton.qml
+++ b/qml/TextButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
 
 Label {
     id: label

--- a/qml/TextButton.qml
+++ b/qml/TextButton.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.5
-import QtQuick.Controls 2.1
+import QtQuick 2.13
+import QtQuick.Controls 2.13
 
 Label {
     id: label

--- a/qml/dummydata/accountBridge.qml
+++ b/qml/dummydata/accountBridge.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.12
 
 QtObject {
     property string username: "username"

--- a/qml/dummydata/accountBridge.qml
+++ b/qml/dummydata/accountBridge.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.13
 
 QtObject {
     property string username: "username"

--- a/qml/dummydata/messageModel.qml
+++ b/qml/dummydata/messageModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.12
 
 ListModel {
     ListElement {

--- a/qml/dummydata/messageModel.qml
+++ b/qml/dummydata/messageModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.13
 
 ListModel {
     ListElement {

--- a/qml/dummydata/notificationModel.qml
+++ b/qml/dummydata/notificationModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.12
 
 ListModel {
     ListElement {

--- a/qml/dummydata/notificationModel.qml
+++ b/qml/dummydata/notificationModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.13
 
 ListModel {
     ListElement {

--- a/qml/dummydata/paneModel.qml
+++ b/qml/dummydata/paneModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.12
 
 ListModel {
     Component.onCompleted: {

--- a/qml/dummydata/paneModel.qml
+++ b/qml/dummydata/paneModel.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.13
 
 ListModel {
     Component.onCompleted: {

--- a/qml/dummydata/settings.qml
+++ b/qml/dummydata/settings.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.12
 
 QtObject {
     property string authURL: "http://example.com/auth"

--- a/qml/dummydata/settings.qml
+++ b/qml/dummydata/settings.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.13
 
 QtObject {
     property string authURL: "http://example.com/auth"

--- a/qml/dummydata/uiBridge.qml
+++ b/qml/dummydata/uiBridge.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.4
+import QtQuick 2.13
 
 QtObject {
     function connectButton(instance) {

--- a/qml/dummydata/uiBridge.qml
+++ b/qml/dummydata/uiBridge.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.13
+import QtQuick 2.12
 
 QtObject {
     function connectButton(instance) {

--- a/qml/telephant.qml
+++ b/qml/telephant.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.13
-import QtQuick.Controls 2.13
-import QtQuick.Controls.Material 2.13
+import QtQuick 2.12
+import QtQuick.Controls 2.12
+import QtQuick.Controls.Material 2.12
 import QtQuick.Layouts 1.11
 
 import "componentCreator.js" as ComponentCreator

--- a/qml/telephant.qml
+++ b/qml/telephant.qml
@@ -1,7 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.2
-import QtQuick.Controls.Material 2.1
-import QtQuick.Layouts 1.3
+import QtQuick 2.13
+import QtQuick.Controls 2.13
+import QtQuick.Controls.Material 2.13
+import QtQuick.Layouts 1.11
 
 import "componentCreator.js" as ComponentCreator
 
@@ -15,6 +15,8 @@ ApplicationWindow {
     background: Rectangle {
         color: Material.color(Material.Grey, Material.Shade900)
     }
+
+    font.family: settings.fontfamily
 
     minimumWidth: 364
     minimumHeight: 590

--- a/telephant.go
+++ b/telephant.go
@@ -145,6 +145,12 @@ func main() {
 	if config.Style == "" {
 		config.Style = "Dark"
 	}
+	if config.FontFamily == "" {
+		config.FontFamily = "Noto Sans"
+	}
+	if config.EmojiFont == "" {
+		config.EmojiFont = "Noto Color Emoji"
+	}
 	configBridge.SetTheme(config.Theme)
 	configBridge.SetStyle(config.Style)
 	configBridge.SetFirstRun(config.FirstRun)
@@ -152,6 +158,8 @@ func main() {
 	configBridge.SetPositionY(config.PositionY)
 	configBridge.SetWidth(config.Width)
 	configBridge.SetHeight(config.Height)
+	configBridge.SetFontfamily(config.FontFamily)
+	configBridge.SetEmojifont(config.EmojiFont)
 
 	accountBridge.SetUsername("Not connected...")
 	accountBridge.SetNotifications(notificationModel)
@@ -178,5 +186,7 @@ func main() {
 	config.Width = configBridge.Width()
 	config.Height = configBridge.Height()
 	config.FirstRun = false
+	config.FontFamily = configBridge.Fontfamily()
+	config.EmojiFont = configBridge.Emojifont()
 	SaveConfig(configFile, config)
 }


### PR DESCRIPTION
This makes it possible to set custom fonts for the application. It also adds a separate setting for which font should be used for Emojis and parses display names and posts to put the emojis into font tags.
It's also a bit of preparation for supporting custom emojis, as that would be the same logic, just replacing with img tags and such.

It also upgrades the imports in the qml files to the most recent supported ones in Qt 5.13. This one cost me a fair bit of my sanity actually, because if couldn't figure out at all why the emojis showed up rendered all over the place and just not right at all. Turns out that imports are "use exactly this version" and not "minimum version" which means all the bugs are preserved too.

As therecipe/qt supports 5.13 and 5.12 right now, i just went ahead and looked up which the most recent versions are and bumped it to those.